### PR TITLE
fix: allow null customerName/customerSurname on MovementBackOfficeData

### DIFF
--- a/src/Responses/DataModels/MovementBackOfficeData.php
+++ b/src/Responses/DataModels/MovementBackOfficeData.php
@@ -15,8 +15,8 @@ class MovementBackOfficeData extends DataTransferObject
     public int $kind;
     public ?string $kindDescription;
     public int $customer;
-    public string $customerName;
-    public string $customerSurname;
+    public ?string $customerName;
+    public ?string $customerSurname;
     public int $operatorId;
     public string $dateTime;
     public string $localTime;

--- a/tests/DataModels/MovementBackOfficeDataTest.php
+++ b/tests/DataModels/MovementBackOfficeDataTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Blabs\FidelyNet\Test\DataModels;
+
+use Blabs\FidelyNet\Responses\DataModels\MovementBackOfficeData;
+use PHPUnit\Framework\TestCase;
+
+class MovementBackOfficeDataTest extends TestCase
+{
+    /**
+     * FidelyNet returns null on customerName/customerSurname for some movements
+     * (e.g. anonymized customers). The DTO must accept null on both fields.
+     */
+    public function test_accepts_null_customer_name_and_surname(): void
+    {
+        $movement = new MovementBackOfficeData([
+            'id' => 1,
+            'campaign' => 1,
+            'terminal' => 0,
+            'shopId' => 0,
+            'card' => 1,
+            'cardOld' => '',
+            'kind' => 1,
+            'kindDescription' => null,
+            'customer' => 1,
+            'customerName' => null,
+            'customerSurname' => null,
+            'operatorId' => 0,
+            'dateTime' => '2026-01-01T00:00:00.000+02:00',
+            'localTime' => '2026-01-01T02:00:00.000+02:00',
+            'chargedCredits' => 0.0,
+            'chargedGiftCredits' => 0.0,
+            'chargedPoints' => 0.0,
+            'chargedPointsStatus' => 0,
+            'dischargedCredits' => 0.0,
+            'dischargedGiftCredits' => 0.0,
+            'dischargedPoints' => 0.0,
+            'dischargedPointsStatus' => 0,
+            'currencyConversion' => 0,
+            'profitMoneyLocal' => 0,
+            'totalMoney' => 0.0,
+            'totalBenefits' => 0,
+            'discount' => 0,
+            'paymentMethodId' => 0,
+            'kindCharge' => null,
+            'promotionErrorCode' => null,
+            'sellerId' => null,
+        ]);
+
+        $this->assertNull($movement->customerName);
+        $this->assertNull($movement->customerSurname);
+    }
+}


### PR DESCRIPTION
Fixes #47.

## What

Make `customerName` and `customerSurname` nullable on `MovementBackOfficeData`, mirroring the existing nullable typing on `kindDescription`.

```diff
-    public string $customerName;
-    public string $customerSurname;
+    public ?string $customerName;
+    public ?string $customerSurname;
```

## Why

FidelyNet returns `null` on these two fields for some movements (we see it consistently on records whose underlying customer is anonymized / soft-deleted, and occasionally on virtual-card flows).

With the current non-nullable typing, hydration of `MovementBackOfficeData` throws:

```
Cannot assign null to property Blabs\FidelyNet\Responses\DataModels\MovementBackOfficeData::$customerSurname of type string
```

The exception is raised inside `getAllMovements()` while the SDK is materializing the page, which means **a single bad record aborts the whole response page** — the consumer can't even keep the rest of that page, let alone reach the next one. See #47 for the full impact write-up.

## Tests

Added `tests/DataModels/MovementBackOfficeDataTest.php` covering the null case directly on the DTO. Full suite still green:

```
OK, but incomplete, skipped, or risky tests!
Tests: 74, Assertions: 204, Skipped: 2, Risky: 3.
```

(The 2 skipped + 3 risky are pre-existing — unrelated PHP 8.4 deprecations and `markTestSkipped` calls.)

## Target branch

Targeting `v2` since that is the active branch consumers track via `^2.x`. Happy to also retarget / cherry-pick to `main` if you prefer.